### PR TITLE
Update SPDX library versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <dependency>
     	<groupId>org.spdx</groupId>
     	<artifactId>java-spdx-library</artifactId>
-    	<version>1.1.6</version>
+    	<version>1.1.10</version>
     </dependency>
     <dependency>
     <!-- Note: CycloneDX library fails with version 2.15.0-rc3 -->
@@ -119,22 +119,22 @@
     <dependency>
     	<groupId>org.spdx</groupId>
     	<artifactId>spdx-rdf-store</artifactId>
-    	<version>1.1.6</version>
+    	<version>1.1.9</version>
     </dependency>
     <dependency>
     	<groupId>org.spdx</groupId>
     	<artifactId>spdx-jackson-store</artifactId>
-    	<version>1.1.6</version>
+    	<version>1.1.9.1</version>
     </dependency>
     <dependency>
     	<groupId>org.spdx</groupId>
     	<artifactId>spdx-tagvalue-store</artifactId>
-    	<version>1.1.6</version>
+    	<version>1.1.7</version>
     </dependency>
     <dependency>
     	<groupId>org.spdx</groupId>
     	<artifactId>spdx-spreadsheet-store</artifactId>
-    	<version>1.1.6</version>
+    	<version>1.1.7</version>
     </dependency>
   </dependencies>
     <build>


### PR DESCRIPTION
Fixes issue with generating SPDX files which do not validate if they include a primary purpose of OPERATING_SYSTEM.